### PR TITLE
Fix RSSI for 9560, fix linking errors

### DIFF
--- a/itlwm/interop.cpp
+++ b/itlwm/interop.cpp
@@ -227,7 +227,8 @@ void itlwm::getRSNIE(uint16_t &ie_len, uint8_t ie_buf[257]) {
 }
 
 int itlwm::getRSSI() {
-	return iwm_get_signal_strength(&com, &com.sc_last_phy_info);
+    ieee80211_node *bss = com.sc_ic.ic_bss;
+    return -(bss->ni_rssi);
 }
 
 int itlwm::getNoise() {

--- a/itlwm/interop.hpp
+++ b/itlwm/interop.hpp
@@ -77,11 +77,11 @@ public:
 	virtual IOCommandGate *getCommandGate() const = 0;
 	virtual const OSString * newVendorString() const = 0;
     virtual const OSString * newModelString() const = 0;
-	virtual void getFirmwareVersion(char version[256], uint16_t &version_len);
-	virtual uint32_t getPHYMode();
-	virtual uint32_t getSupportedPHYModes();
-	virtual uint32_t getOpMode();
-	virtual void getCountryCode(char countryCode[3]);
+	virtual void getFirmwareVersion(char version[256], uint16_t &version_len) = 0;
+	virtual uint32_t getPHYMode() = 0;
+	virtual uint32_t getSupportedPHYModes() = 0;
+	virtual uint32_t getOpMode() = 0;
+	virtual void getCountryCode(char countryCode[3]) = 0;
 };
 
 #endif /* interop_hpp */


### PR DESCRIPTION
This fixes issue https://github.com/usr-sse2/Black80211-Catalina/issues/17, and returns the value that HeliPort uses. iwm_get_signal_strength was only used for models older than 9xxx cards.

I was getting linking errors as well from `kextutil` without setting the virtual methods under Black80211Device to zero.